### PR TITLE
Fix regado persistence

### DIFF
--- a/script.js
+++ b/script.js
@@ -307,6 +307,10 @@ function agregarTarjetaCultivo(info) {
     `;
     wateringSelect.addEventListener('change', (e) => {
         info.regado = parseInt(e.target.value);
+        const cultivo = cultivosPlantados.find(c => c.nombre === info.nombre);
+        if (cultivo) {
+            cultivo.regado = info.regado;
+        }
         actualizarPuntosCultivo(info.nombre);
         guardarCultivosEnLocalStorage();
     });


### PR DESCRIPTION
## Summary
- keep watering value in sync with stored crop data

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_685323387b90832f8f664e7eaf1c04a5